### PR TITLE
LR/SC Wrapper for Spandex

### DIFF
--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -190,7 +190,7 @@ module axi_riscv_lrsc #(
     assign mst_ar_len_o       = slv_ar_len_i;
     assign mst_ar_size_o      = slv_ar_size_i;
     assign mst_ar_burst_o     = slv_ar_burst_i;
-    assign mst_ar_lock_o      = slv_ar_lock_i  | (|slv_ar_atop_i);
+    assign mst_ar_lock_o      = slv_ar_lock_i | (|slv_ar_atop_i);
     assign mst_ar_cache_o     = slv_ar_cache_i;
     assign mst_ar_qos_o       = slv_ar_qos_i;
     assign mst_ar_id_o        = slv_ar_id_i;

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -190,7 +190,7 @@ module axi_riscv_lrsc #(
     assign mst_ar_len_o       = slv_ar_len_i;
     assign mst_ar_size_o      = slv_ar_size_i;
     assign mst_ar_burst_o     = slv_ar_burst_i;
-    assign mst_ar_lock_o      = slv_ar_lock_i;
+    assign mst_ar_lock_o      = slv_ar_lock_i  | (|slv_ar_atop_i);
     assign mst_ar_cache_o     = slv_ar_cache_i;
     assign mst_ar_qos_o       = slv_ar_qos_i;
     assign mst_ar_id_o        = slv_ar_id_i;
@@ -292,7 +292,7 @@ module axi_riscv_lrsc #(
     assign mst_aw_len_o     = slv_aw_len_i;
     assign mst_aw_size_o    = slv_aw_size_i;
     assign mst_aw_burst_o   = slv_aw_burst_i;
-    assign mst_aw_lock_o    = slv_aw_lock_i;
+    assign mst_aw_lock_o    = slv_aw_lock_i | (|slv_aw_atop_i);
     assign mst_aw_cache_o   = slv_aw_cache_i;
     assign mst_aw_qos_o     = slv_aw_qos_i;
     assign mst_aw_id_o      = slv_aw_id_i;

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -190,7 +190,7 @@ module axi_riscv_lrsc #(
     assign mst_ar_len_o       = slv_ar_len_i;
     assign mst_ar_size_o      = slv_ar_size_i;
     assign mst_ar_burst_o     = slv_ar_burst_i;
-    assign mst_ar_lock_o      = slv_ar_lock_i | (|slv_ar_atop_i);
+    assign mst_ar_lock_o      = slv_ar_lock_i;
     assign mst_ar_cache_o     = slv_ar_cache_i;
     assign mst_ar_qos_o       = slv_ar_qos_i;
     assign mst_ar_id_o        = slv_ar_id_i;
@@ -292,7 +292,7 @@ module axi_riscv_lrsc #(
     assign mst_aw_len_o     = slv_aw_len_i;
     assign mst_aw_size_o    = slv_aw_size_i;
     assign mst_aw_burst_o   = slv_aw_burst_i;
-    assign mst_aw_lock_o    = slv_aw_lock_i | (|slv_aw_atop_i);
+    assign mst_aw_lock_o    = slv_aw_lock_i;
     assign mst_aw_cache_o   = slv_aw_cache_i;
     assign mst_aw_qos_o     = slv_aw_qos_i;
     assign mst_aw_id_o      = slv_aw_id_i;

--- a/src/axi_riscv_lrsc.sv
+++ b/src/axi_riscv_lrsc.sv
@@ -63,6 +63,7 @@ module axi_riscv_lrsc #(
     input  logic [AXI_ADDR_WIDTH-1:0]   slv_ar_addr_i,
     input  logic [2:0]                  slv_ar_prot_i,
     input  logic [3:0]                  slv_ar_region_i,
+    input  logic [5:0]                  slv_ar_atop_i,
     input  logic [7:0]                  slv_ar_len_i,
     input  logic [2:0]                  slv_ar_size_i,
     input  logic [1:0]                  slv_ar_burst_i,


### PR DESCRIPTION
This PR contains the required RISC-V lrsc wrapper patch that Spandex uses. It directly exposes ATOP to the next level Spandex cache, and waits for the response from the cache.